### PR TITLE
Fixed tail-call-optimization, new nested defines, let, let*, letrec*

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Again another Scheme, this time by Gemini 2.5 Pro (preview)
 - [x] Predicate tester functions
 - [x] String functions
 - [x] eval, write, read
-- [ ] Conversion between types
+- [x] Conversion between types
 - [x] Implement symbol interning in sl_make_symbol so that only one symbol object exists per unique name.
 - [ ] Refine lambda/define syntax validation (variadics?), variable arity support (lambda)
 - [ ] Nested defines

--- a/symlisplib/sl_core.h
+++ b/symlisplib/sl_core.h
@@ -25,7 +25,8 @@ typedef enum {
     SL_TYPE_ENV,
     SL_TYPE_ERROR,  // New type for error objects
     SL_TYPE_CHAR,
-    SL_TYPE_EOF,  // New type for EOF object
+    SL_TYPE_EOF,       // New type for EOF object
+    SL_TYPE_UNDEFINED  // <<< ADDED: Placeholder for letrec*/define
 } sl_object_type;
 
 // --- Number Representation ---
@@ -103,6 +104,8 @@ extern sl_object *SL_FALSE;
 extern sl_object *SL_EOF_OBJECT;           // <<< ADDED
 extern sl_object *SL_OUT_OF_MEMORY_ERROR;  // <<< ADDED
 extern sl_object *SL_PARSE_ERROR;
+extern sl_object *SL_UNDEFINED;        // <<< ADDED
+#define SL_CONTINUE_EVAL SL_UNDEFINED  // <<< ADDED: Marker for TCO jump
 
 // --- Helper macro for checking allocation result ---
 #define CHECK_ALLOC(obj_ptr)                                                         \


### PR DESCRIPTION
- Tail-call-optimization (TCO) now works, significant speed-up on recursion
- Nested `define` support
- `let`, `let*`, `letrec*` support.
